### PR TITLE
Prevent NullPointerException in DownloadBroadcastReceiver

### DIFF
--- a/src/android/com/pchab/android/plugin/Downloader.java
+++ b/src/android/com/pchab/android/plugin/Downloader.java
@@ -135,6 +135,9 @@ public class Downloader extends CordovaPlugin {
             //Retrieve the saved download
             Download currentDownload = downloadMap.get(downloadId);
             downloadMap.remove(downloadId);
+            if(currentDownload == null || currentDownload.callbackContext == null) {
+              return;
+            }
 
             int columnIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS);
             int status = cursor.getInt(columnIndex);


### PR DESCRIPTION
When receiving a broadcast intent without a download ID or with an ID not found in the local map, the code attempted to access the 'callbackContext' on a null download cursor reference, leading to the exception.

Check the download cursor and 'callbackContext' for null values to prevent this issue.