### PR TITLE
[Android] Fix SecurityException crash on Android 14 (API level 34) and above

### DIFF
--- a/src/android/com/pchab/android/plugin/Downloader.java
+++ b/src/android/com/pchab/android/plugin/Downloader.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 
@@ -37,9 +38,13 @@ public class Downloader extends CordovaPlugin {
 
         downloadManager = (DownloadManager) cordovaActivity.getSystemService(Context.DOWNLOAD_SERVICE);
         downloadMap = new HashMap<>();
-
+        IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
         // Register receiver for Notification actions
-        cordovaActivity.registerReceiver(downloadReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        if (Build.VERSION.SDK_INT >= 34) {
+            cordovaActivity.registerReceiver(downloadReceiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            cordovaActivity.registerReceiver(downloadReceiver, filter);
+        }
     }
 
     @Override


### PR DESCRIPTION
Some users reported app crashes due to a SecurityException with the message: "One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts". This issue occurs when users attempt to download a file on devices running Android 14 (API level 34) and above. 

Android 14 (API level 34) introduces stricter requirements for apps using context-registered receivers, where a flag must be specified to indicate whether the receiver is exported to other apps [1].

Set the `RECEIVER_EXPORTED` flag when registering the download receiver for API level 34 and above in order to meet the requirement that prevents app crashes.

[1]: https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported